### PR TITLE
feat: add a new buildpack to detect func.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,27 +25,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Determine download URL for latest pack
-        id: pack-download-url
-        uses: actions/github-script@v2
-        with:
-          result-encoding: string
-          script: |
-            return github.repos.getReleaseByTag({
-                owner: "buildpacks",
-                repo: "pack",
-                tag: "v0.20.0"
-            }).then(result => {
-                return result.data.assets
-                  .filter(a => a.name.includes("linux"))
-                  .map(a => a.browser_download_url)[0];
-            })
       - name: Install pack
-        run: |
-          curl -s -L -o pack.tgz ${{ steps.pack-download-url.outputs.result }}
-          tar -xvf pack.tgz
+        uses: buildpacks/github-actions/setup-pack@v4.1.0
+        with:
+          pack-version: 0.23.0
+
+
       - name: Build
-        run: PACK_CMD="$(pwd)/pack" make
+        run: make
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -16,29 +16,13 @@ jobs:
         with:
           go-version: 1.16
 
-      - name: Determine download URL for latest pack
-        id: pack-download-url
-        uses: actions/github-script@v2
-        with:
-          result-encoding: string
-          script: |
-            return github.repos.getReleaseByTag({
-                owner: "buildpacks",
-                repo: "pack",
-                tag: "v0.20.0"
-            }).then(result => {
-                return result.data.assets
-                  .filter(a => a.name.includes("linux"))
-                  .map(a => a.browser_download_url)[0];
-            })
-
       - name: Install pack
-        run: |
-          curl -s -L -o pack.tgz ${{ steps.pack-download-url.outputs.result }}
-          tar -xvf pack.tgz
-          
+        uses: buildpacks/github-actions/setup-pack@v4.1.0
+        with:
+          pack-version: 0.23.0
+
       - name: Build
-        run: PACK_CMD="$(pwd)/pack" make
+        run: make
 
       - name: Run tests
-        run: PACK_CMD="$(pwd)/pack" make test
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-bin
+/bin
 test/testdata

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,7 @@ publish:
 	./hack/make.sh publish $(VERSION_TAG)
 
 test: buildpacks
+	# The tests in make.sh cover the base boson-function-buildpack image
+	./hack/make.sh test $(VERSION_TAG)
+	# The go tests integration with kn-plugin-func
 	VERSION_TAG=$(VERSION_TAG) go test -v ./test/...

--- a/buildpacks/boson/bin/build
+++ b/buildpacks/boson/bin/build
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo ">"
+echo "> Knative Func Buildpack"
+echo ">"
+
+cat > "$1/launch.toml" << EOF
+[[processes]]
+type = "web"
+command = "echo Knative Func"
+EOF

--- a/buildpacks/boson/bin/detect
+++ b/buildpacks/boson/bin/detect
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -eo pipefail
+plan=$2 
+
+echo "> Knative Function Buildpack"
+
+if [[ ! -f func.yaml ]] ; then
+  echo "> Knative Function project not detected"
+  exit 100
+fi
+
+echo "> Knative Function project detected"
+
+cat >> $plan <<EOM
+[[provides]]
+  name = "boson"
+
+[[requires]]
+  name = "boson"
+EOM

--- a/buildpacks/boson/buildpack.toml
+++ b/buildpacks/boson/buildpack.toml
@@ -1,0 +1,12 @@
+api = "0.2"
+
+[buildpack]
+id = "dev.knative-sandbox.func"
+version = "0.0.2"
+name = "Function Buildpack"
+
+[[stacks]]
+id = "io.paketo.stacks.tiny"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"

--- a/buildpacks/go/bin/detect
+++ b/buildpacks/go/bin/detect
@@ -19,4 +19,7 @@ cat >> $plan <<EOM
 
 [[requires]]
   name = "func-framework"
+
+[[requires]]
+  name = "boson"
 EOM

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -7,7 +7,7 @@ VERSION="${2-tip}"
 REPOSITORY="ghcr.io/boson-project"
 PACK_CMD=${PACK_CMD:-pack}
 
-BUILDPACKS=(go)
+BUILDPACKS=(boson go)
 
 buildpack_to_img() { echo "${REPOSITORY}/${1}-function-buildpack:${2}"; }
 
@@ -32,13 +32,26 @@ make_publish() {
   done
 }
 
+make_test() {
+  # Try building in a directory known not to have a func.yaml and look for "Knative Function project not detected"
+  local OUT=`$PACK_CMD build boson-func-test --pull-policy if-not-present --buildpack ghcr.io/boson-project/boson-function-buildpack:tip  -v --trust-builder --builder gcr.io/paketo-buildpacks/builder:base --path ./test/testdata`
+  echo $OUT | grep "Knative Function project not detected"
+
+  # Try building in a directory with a func.yaml and expect no errors
+  mkdir -p ./test/testdata/func && touch ./test/testdata/func/func.yaml
+	$PACK_CMD build boson-func-test --pull-policy if-not-present --buildpack ghcr.io/boson-project/boson-function-buildpack:tip  -v --trust-builder --builder gcr.io/paketo-buildpacks/builder:base --path ./test/testdata/func
+}
+
 case $1 in
   "buildpacks")
     make_buildpacks
     ;;
   "publish")
-  make_publish
-  ;;
+    make_publish
+    ;;
+  "test")
+    make_test
+    ;;
   *)
     echo "invalid command"
     exit 1

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -33,12 +33,13 @@ make_publish() {
 }
 
 make_test() {
+  mkdir -p ./test/testdata/func && touch ./test/testdata/func/func.yaml
+
   # Try building in a directory known not to have a func.yaml and look for "Knative Function project not detected"
   local OUT=`$PACK_CMD build boson-func-test --pull-policy if-not-present --buildpack ghcr.io/boson-project/boson-function-buildpack:tip  -v --trust-builder --builder gcr.io/paketo-buildpacks/builder:base --path ./test/testdata`
   echo $OUT | grep "Knative Function project not detected"
 
   # Try building in a directory with a func.yaml and expect no errors
-  mkdir -p ./test/testdata/func && touch ./test/testdata/func/func.yaml
 	$PACK_CMD build boson-func-test --pull-policy if-not-present --buildpack ghcr.io/boson-project/boson-function-buildpack:tip  -v --trust-builder --builder gcr.io/paketo-buildpacks/builder:base --path ./test/testdata/func
 }
 


### PR DESCRIPTION
This commit adds a new buildpack which has a singular purpose of checking
for a func.yaml file in the project directory and failing if one does not
exist.

* `ghcr.io/boson-project/boson-function-buildpack`

To use it, add the following to your buildpack's build plan.

```
[[requires]]
  name = "boson"
```

This commit introduces that dependency on the existing Go buildpack.

The `detect` script could be improved to check for additional metadata in
the func.yaml file if we feel that a check for simple existence isn't enough.

Tests have been added that introduces the `pack` dependency in the build
to test this buildpack. Tests were added for both the success and failure case.

Signed-off-by: Lance Ball <lball@redhat.com>