### PR TITLE
remove file deletion command after build

### DIFF
--- a/builders/go/builder.toml
+++ b/builders/go/builder.toml
@@ -12,6 +12,7 @@ uri = "../../buildpacks/go"
 
   [[order.group]]
     id = "dev.knative-sandbox.go"
+    version = "0.0.3"
 
 [stack]
   build-image = "docker.io/paketobuildpacks/build:1.3.10-full-cnb"

--- a/buildpacks/go/bin/build
+++ b/buildpacks/go/bin/build
@@ -27,8 +27,6 @@ cache = false
 EOF
 
 cp $build_dir/bin/faas "$app_layer/faas"
-chmod u+w -R $build_dir
-rm -fr $build_dir/* $build_dir/.[a-z]*
 
 # LAUNCHER
 cat > "$layers_dir/launch.toml" << EOF

--- a/buildpacks/go/buildpack.toml
+++ b/buildpacks/go/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.2"
 
 [buildpack]
 id = "dev.knative-sandbox.go"
-version = "0.0.2"
+version = "0.0.3"
 name = "Go Function Buildpack"
 
 [[stacks]]


### PR DESCRIPTION
While running the on cluster build for go runtime, using the builder `ghcr.io/boson-project/go-function-builder:tip` in `func.yaml`, makes the `image-digest` step fail because it is unable to locate the `func.yaml` file in `/workspace/source/`, which I suspect is because of: https://github.com/boson-project/packs/blob/main/buildpacks/go/bin/build#L31

This change could probably be a fix, it seems to work in my setup (I am not aware/sure if that `rm` command is serving some purpose or completely unrelated here) I have upgraded the version of the scaffolding buildpack to 0.0.3 and I can see it being reflected in the `buildpacks` task - not sure if it should be incremented or kept the same as before - 0.0.2 

this will undo: https://github.com/knative-sandbox/kn-plugin-func/issues/357

more context: https://knative.slack.com/archives/CUU6LEMRT/p1643893973744699